### PR TITLE
Update for PHP5

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 
 require_once('phprestsql.php');
 
-$PHPRestSQL =& new PHPRestSQL();
+$PHPRestSQL = new PHPRestSQL();
 $PHPRestSQL->exec();
 
 /*


### PR DESCRIPTION
The use of & cases a deprecated disclosure on PHP5.
Just removed & and it works for me.
